### PR TITLE
Feature/retrieve and install dependencies with maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
     <properties>
         <nexus.docker.version>3.45.0</nexus.docker.version>
         <nexus.pkg.version>3.45.0-01</nexus.pkg.version>
+        <nexus.binary.url>https://download.sonatype.com/nexus/3/nexus-${nexus.version}-unix.tar.gz</nexus.binary.url>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss</maven.build.timestamp.format>
         <maven-surefire-plugin.version>3.0.0-M8</maven-surefire-plugin.version>
@@ -67,6 +68,9 @@
         <retrofit.version>2.9.0</retrofit.version>
         <allure.version>2.20.1</allure.version>
         <aspectj.version>1.9.19</aspectj.version>
+        <cfg.repopath>${project.basedir}/mvnrepo</cfg.repopath>
+        <plg.version.download-maven-plugin>1.6.5</plg.version.download-maven-plugin>
+        <plg.version.maven-install-plugin>3.1.0</plg.version.maven-install-plugin>
     </properties>
 
     <dependencyManagement>
@@ -477,7 +481,7 @@
                                     <gpgArguments>
                                         <arg>--pinentry-mode</arg>
                                         <arg>loopback</arg>
-                                    </gpgArguments>
+                                     </gpgArguments>
                                 </configuration>
                             </execution>
                         </executions>
@@ -492,6 +496,113 @@
                             <nexusUrl>https://oss.sonatype.org</nexusUrl>
                             <autoReleaseAfterClose>true</autoReleaseAfterClose>
                         </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>prepare</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <properties>
+                <enforcer.skip>true</enforcer.skip>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-clean-plugin</artifactId>
+                        <version>3.2.0</version>
+                        <executions>
+                            <execution>
+                                <id>clean-cache-local-repo</id>
+                                <goals>
+                                    <goal>clean</goal>
+                                </goals>
+                                <phase>clean</phase>
+                                <configuration>
+                                    <filesets>
+                                        <fileset>
+                                            <directory>${pom.basedir}/.cache</directory>
+                                        </fileset>
+                                        <fileset>
+                                            <directory>${cfg.repopath}</directory>
+                                        </fileset>
+                                    </filesets>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>com.googlecode.maven-download-plugin</groupId>
+                        <artifactId>download-maven-plugin</artifactId>
+                        <version>${plg.version.download-maven-plugin}</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>wget</goal>
+                                </goals>
+                                <phase>generate-resources</phase>
+                                <configuration>
+                                    <runOnlyAtRoot>true</runOnlyAtRoot>
+                                    <url>${nexus.binary.url}</url>
+                                    <outputFileName>nexus.tar.gz</outputFileName>
+                                    <outputDirectory>${project.build.directory}/nexus-binaries</outputDirectory>
+                                    <unpack>true</unpack>
+                                    <cacheDirectory>${basedir}/.cache</cacheDirectory>
+                                    <skipCache>false</skipCache>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-install-plugin</artifactId>
+                        <version>${plg.version.maven-install-plugin}</version>
+                        <configuration>
+                            <localRepositoryPath>${cfg.repopath}</localRepositoryPath>
+                            <generatePom>true</generatePom>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>nexus-licensing-extension</id>
+                                <goals>
+                                    <goal>install-file</goal>
+                                </goals>
+                                <phase>process-resources</phase>
+                                <configuration>
+                                    <file>
+                                        target/nexus-binaries/nexus-${nexus.pkg.version}/system/com/sonatype/nexus/nexus-licensing-extension/${nexus.pkg.version}/nexus-licensing-extension-${nexus.pkg.version}.jar
+                                    </file>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>nexus-ldap-plugin</id>
+                                <goals>
+                                    <goal>install-file</goal>
+                                </goals>
+                                <phase>process-resources</phase>
+                                <configuration>
+                                    <file>
+                                        target/nexus-binaries/nexus-${nexus.pkg.version}/system/com/sonatype/nexus/plugins/nexus-ldap-plugin/${nexus.pkg.version}/nexus-ldap-plugin-${nexus.pkg.version}.jar
+                                    </file>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>nexus-healthcheck-base</id>
+                                <goals>
+                                    <goal>install-file</goal>
+                                </goals>
+                                <phase>process-resources</phase>
+                                <configuration>
+                                    <file>
+                                        target/nexus-binaries/nexus-${nexus.pkg.version}/system/com/sonatype/nexus/plugins/nexus-healthcheck-base/${nexus.pkg.version}/nexus-healthcheck-base-${nexus.pkg.version}.jar
+                                    </file>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/pom.xml
+++ b/pom.xml
@@ -373,6 +373,7 @@
             <url>file://${project.basedir}/mvnrepo</url>
             <releases>
                 <enabled>true</enabled>
+                <checksumPolicy>ignore</checksumPolicy>
             </releases>
         </repository>
     </repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
         <cfg.repopath>${project.basedir}/mvnrepo</cfg.repopath>
         <plg.version.download-maven-plugin>1.6.5</plg.version.download-maven-plugin>
         <plg.version.maven-install-plugin>3.1.0</plg.version.maven-install-plugin>
+        <plg.version.maven-clean-plugin>3.2.0</plg.version.maven-clean-plugin>
     </properties>
 
     <dependencyManagement>
@@ -515,7 +516,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-clean-plugin</artifactId>
-                        <version>3.2.0</version>
+                        <version>${plg.version.maven-clean-plugin}</version>
                         <executions>
                             <execution>
                                 <id>clean-cache-local-repo</id>


### PR DESCRIPTION
Functions:
* Downnloading and unpacking package: **nexus-${VER}-unix.tar.gz**
* Install required dependencies to local maven repository

Note: The checksum generation feature was dropped in some earlier release of  the install plugin.
Maybe the didn't like SHA-1 and MD5 any more.

Usage:
`mvn -Pprepare process-resources`
then do a regular build:
`mvn clean verify`